### PR TITLE
POS-1093 Support power_enum >= 4.0

### DIFF
--- a/enum_state_machine.gemspec
+++ b/enum_state_machine.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", ">= 6.0", "< 7.0"
   s.add_dependency "activerecord-deprecated_finders", ">= 1.0.3"
   #s.add_dependency "rails-observers", ">= 0.1.2"
-  s.add_dependency "power_enum", "> 2.8", "< 4.0"
+  s.add_dependency "power_enum", "> 2.8"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "minitest", "~> 5.1"

--- a/lib/enum_state_machine/version.rb
+++ b/lib/enum_state_machine/version.rb
@@ -1,3 +1,3 @@
 module EnumStateMachine
-  VERSION = "0.8.0"
+  VERSION = "0.8.1"
 end


### PR DESCRIPTION
Support `power_enum` >= 4.0. This allows `create_enum` migrations to go through on ruby >= 3.0

See: https://github.com/CityBaseInc/cb_pos/pull/2123