### PR TITLE
POS-1096 Support rails >= 7.0

### DIFF
--- a/enum_state_machine.gemspec
+++ b/enum_state_machine.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files  = %w(README.md CHANGELOG.md LICENSE)
   s.license           = 'MIT'
 
-  s.add_dependency "rails", ">= 6.0", "< 7.0"
+  s.add_dependency "rails", ">= 6.0", "< 8.0"
   s.add_dependency "activerecord-deprecated_finders", ">= 1.0.3"
   #s.add_dependency "rails-observers", ">= 0.1.2"
   s.add_dependency "power_enum", "> 2.8"

--- a/lib/enum_state_machine/version.rb
+++ b/lib/enum_state_machine/version.rb
@@ -1,3 +1,3 @@
 module EnumStateMachine
-  VERSION = "0.8.1"
+  VERSION = "0.8.2"
 end


### PR DESCRIPTION
# Description
This PR adds support for rails 7 simply by removing the restriction in the `gemspec`. 

## Changes
- Gemspec allows rails ">= 6.0", "< 8.0"
- Increase version to 0.8.2